### PR TITLE
Add `formatQuestionForQuestionContainsKeywordsPredicate` method at `QuestionContainsKeywordPredicate`

### DIFF
--- a/src/main/java/seedu/address/model/flashcard/QuestionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/flashcard/QuestionContainsKeywordsPredicate.java
@@ -16,11 +16,11 @@ public class QuestionContainsKeywordsPredicate implements Predicate<Flashcard> {
     }
 
     /**
-     * Formats the question for find command by adding whitespace between special characters.
+     * Formats the question for QuestionContainsKeywordsPredicate by adding whitespace between special characters.
      * @param question Question to format.
      * @return Returns a formatted question.
      */
-    public String formatQuestionForFindCommand(Question question) {
+    public String formatQuestionForQuestionContainsKeywordsPredicate(Question question) {
         return question.toString().replaceAll("[^a-zA-Z0-9]", " $0 ");
     }
 
@@ -28,7 +28,8 @@ public class QuestionContainsKeywordsPredicate implements Predicate<Flashcard> {
     public boolean test(Flashcard flashcard) {
         return keywords.stream()
                 .anyMatch(keyword ->
-                    StringUtil.containsWordIgnoreCase(formatQuestionForFindCommand(flashcard.getQuestion()), keyword));
+                    StringUtil.containsWordIgnoreCase(
+                            formatQuestionForQuestionContainsKeywordsPredicate(flashcard.getQuestion()), keyword));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/flashcard/QuestionContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/flashcard/QuestionContainsKeywordsPredicate.java
@@ -15,10 +15,20 @@ public class QuestionContainsKeywordsPredicate implements Predicate<Flashcard> {
         this.keywords = keywords;
     }
 
+    /**
+     * Formats the question for find command by adding whitespace between special characters.
+     * @param question Question to format.
+     * @return Returns a formatted question.
+     */
+    public String formatQuestionForFindCommand(Question question) {
+        return question.toString().replaceAll("[^a-zA-Z0-9]", " $0 ");
+    }
+
     @Override
     public boolean test(Flashcard flashcard) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(flashcard.getQuestion().toString(), keyword));
+                .anyMatch(keyword ->
+                    StringUtil.containsWordIgnoreCase(formatQuestionForFindCommand(flashcard.getQuestion()), keyword));
     }
 
     @Override


### PR DESCRIPTION
This PR adds`formatQuestionForQuestionContainsKeywordsPredicate` method at `QuestionContainsKeywordPredicate`. `formatQuestionForFindCommand` formats the question by adding a whitespace between all special characters. 