### PR TITLE
Correct indentation for UC extension

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -694,7 +694,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
     
 * *a. At any time, User requests to quit review mode.
 
-    *a1. SWEe! quits review mode.
+    * *a1. SWEe! quits review mode.
     
     Use case ends.
 
@@ -723,7 +723,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * *a. At any time, User requests to quit quiz mode.
 
-    *a1. SWEe! quits quiz mode.
+    * *a1. SWEe! quits quiz mode.
     
     Use case ends.
 


### PR DESCRIPTION
Previously: 
![image](https://user-images.githubusercontent.com/50537671/98456767-72e34f80-21bc-11eb-947e-2a6b5c05d520.png)

Now:
![image](https://user-images.githubusercontent.com/50537671/98456748-69f27e00-21bc-11eb-92d7-7d6255fb2688.png)
